### PR TITLE
githubのレポジトリの検索を実装した

### DIFF
--- a/lib/home/home_page.dart
+++ b/lib/home/home_page.dart
@@ -11,7 +11,10 @@ class HomePage extends ConsumerWidget {
     final viewModel = ref.watch(homeViewModelProvider.notifier);
     return state.when(
       data: (data) {
-        return Scaffold();
+        return Scaffold(
+          appBar: AppBar(title: const Text("test")),
+          body: TextFormField(),
+        );
       },
       error: (e, msg) => Text("$msg"),
       loading: () => const Center(

--- a/lib/home/home_page.dart
+++ b/lib/home/home_page.dart
@@ -13,8 +13,22 @@ class HomePage extends ConsumerWidget {
       data: (data) {
         return Scaffold(
           appBar: AppBar(title: const Text("test")),
-          body: TextFormField(
-            onChanged: viewModel.changeSearchWord,
+          body: Column(
+            children: [
+              TextFormField(
+                onChanged: viewModel.changeSearchWord,
+              ),
+              Expanded(
+                child: ListView(
+                  children: data.repositories.map((repo) =>
+                      ListTile(title: Text(repo.name)),
+                  ).toList(),
+                ),
+              ),
+            ],
+          ),
+          floatingActionButton: FloatingActionButton(
+            onPressed: viewModel.searchRepositories,
           ),
         );
       },

--- a/lib/home/home_page.dart
+++ b/lib/home/home_page.dart
@@ -13,7 +13,9 @@ class HomePage extends ConsumerWidget {
       data: (data) {
         return Scaffold(
           appBar: AppBar(title: const Text("test")),
-          body: TextFormField(),
+          body: TextFormField(
+            onChanged: viewModel.changeSearchWord,
+          ),
         );
       },
       error: (e, msg) => Text("$msg"),

--- a/lib/home/home_state.dart
+++ b/lib/home/home_state.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_engineer_codecheck/models/repository.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'home_state.freezed.dart';
@@ -6,5 +7,6 @@ part 'home_state.freezed.dart';
 class HomeState with _$HomeState {
   const factory HomeState({
     @Default("") String searchWord,
+    @Default([]) List<Repository> repositories,
   }) = _HomeState;
 }

--- a/lib/home/home_state.freezed.dart
+++ b/lib/home/home_state.freezed.dart
@@ -17,6 +17,7 @@ final _privateConstructorUsedError = UnsupportedError(
 /// @nodoc
 mixin _$HomeState {
   String get searchWord => throw _privateConstructorUsedError;
+  List<Repository> get repositories => throw _privateConstructorUsedError;
 
   @JsonKey(ignore: true)
   $HomeStateCopyWith<HomeState> get copyWith =>
@@ -27,7 +28,7 @@ mixin _$HomeState {
 abstract class $HomeStateCopyWith<$Res> {
   factory $HomeStateCopyWith(HomeState value, $Res Function(HomeState) then) =
       _$HomeStateCopyWithImpl<$Res>;
-  $Res call({String searchWord});
+  $Res call({String searchWord, List<Repository> repositories});
 }
 
 /// @nodoc
@@ -41,12 +42,17 @@ class _$HomeStateCopyWithImpl<$Res> implements $HomeStateCopyWith<$Res> {
   @override
   $Res call({
     Object? searchWord = freezed,
+    Object? repositories = freezed,
   }) {
     return _then(_value.copyWith(
       searchWord: searchWord == freezed
           ? _value.searchWord
           : searchWord // ignore: cast_nullable_to_non_nullable
               as String,
+      repositories: repositories == freezed
+          ? _value.repositories
+          : repositories // ignore: cast_nullable_to_non_nullable
+              as List<Repository>,
     ));
   }
 }
@@ -57,7 +63,7 @@ abstract class _$$_HomeStateCopyWith<$Res> implements $HomeStateCopyWith<$Res> {
           _$_HomeState value, $Res Function(_$_HomeState) then) =
       __$$_HomeStateCopyWithImpl<$Res>;
   @override
-  $Res call({String searchWord});
+  $Res call({String searchWord, List<Repository> repositories});
 }
 
 /// @nodoc
@@ -73,12 +79,17 @@ class __$$_HomeStateCopyWithImpl<$Res> extends _$HomeStateCopyWithImpl<$Res>
   @override
   $Res call({
     Object? searchWord = freezed,
+    Object? repositories = freezed,
   }) {
     return _then(_$_HomeState(
       searchWord: searchWord == freezed
           ? _value.searchWord
           : searchWord // ignore: cast_nullable_to_non_nullable
               as String,
+      repositories: repositories == freezed
+          ? _value._repositories
+          : repositories // ignore: cast_nullable_to_non_nullable
+              as List<Repository>,
     ));
   }
 }
@@ -86,15 +97,24 @@ class __$$_HomeStateCopyWithImpl<$Res> extends _$HomeStateCopyWithImpl<$Res>
 /// @nodoc
 
 class _$_HomeState implements _HomeState {
-  const _$_HomeState({this.searchWord = ""});
+  const _$_HomeState(
+      {this.searchWord = "", final List<Repository> repositories = const []})
+      : _repositories = repositories;
 
   @override
   @JsonKey()
   final String searchWord;
+  final List<Repository> _repositories;
+  @override
+  @JsonKey()
+  List<Repository> get repositories {
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_repositories);
+  }
 
   @override
   String toString() {
-    return 'HomeState(searchWord: $searchWord)';
+    return 'HomeState(searchWord: $searchWord, repositories: $repositories)';
   }
 
   @override
@@ -103,12 +123,16 @@ class _$_HomeState implements _HomeState {
         (other.runtimeType == runtimeType &&
             other is _$_HomeState &&
             const DeepCollectionEquality()
-                .equals(other.searchWord, searchWord));
+                .equals(other.searchWord, searchWord) &&
+            const DeepCollectionEquality()
+                .equals(other._repositories, _repositories));
   }
 
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, const DeepCollectionEquality().hash(searchWord));
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(searchWord),
+      const DeepCollectionEquality().hash(_repositories));
 
   @JsonKey(ignore: true)
   @override
@@ -117,10 +141,14 @@ class _$_HomeState implements _HomeState {
 }
 
 abstract class _HomeState implements HomeState {
-  const factory _HomeState({final String searchWord}) = _$_HomeState;
+  const factory _HomeState(
+      {final String searchWord,
+      final List<Repository> repositories}) = _$_HomeState;
 
   @override
   String get searchWord;
+  @override
+  List<Repository> get repositories;
   @override
   @JsonKey(ignore: true)
   _$$_HomeStateCopyWith<_$_HomeState> get copyWith =>

--- a/lib/home/home_view_model.dart
+++ b/lib/home/home_view_model.dart
@@ -46,4 +46,9 @@ class HomeViewModel extends StateNotifier<AsyncValue<HomeState>> {
       return repositories;
     }
   }
+
+  Future<void> searchRepositories() async {
+    final repositories = await fetchRepositories(state.value!.searchWord);
+    state = AsyncValue.data(state.value!.copyWith(repositories: repositories));
+  }
 }

--- a/lib/home/home_view_model.dart
+++ b/lib/home/home_view_model.dart
@@ -23,6 +23,7 @@ class HomeViewModel extends StateNotifier<AsyncValue<HomeState>> {
     state = const AsyncValue.data(
       HomeState(
         searchWord: "",
+        repositories: [],
       ),
     );
   }

--- a/lib/home/home_view_model.dart
+++ b/lib/home/home_view_model.dart
@@ -1,5 +1,9 @@
+import 'dart:convert';
+
 import 'package:flutter_engineer_codecheck/home/home_state.dart';
+import 'package:flutter_engineer_codecheck/models/repository.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:http/http.dart' as http;
 
 final homeViewModelProvider =
 StateNotifierProvider.autoDispose<HomeViewModel, AsyncValue<HomeState>>(
@@ -26,5 +30,19 @@ class HomeViewModel extends StateNotifier<AsyncValue<HomeState>> {
   // textFieldとstateの対応
   void changeSearchWord(String value) {
     state = AsyncValue.data(state.value!.copyWith(searchWord: value));
+  }
+
+  Future<List<Repository>> fetchRepositories(String searchWord) async {
+    final res = await http.get(Uri.parse('https://api.github.com/search/repositories?q=$searchWord&sort=stars&order=desc'));
+    List<Repository> repositories = [];
+    if (res.statusCode == 200) {
+      final decoded = json.decode(res.body);
+      for (var item in decoded['items']) {
+        repositories.add(Repository.fromJson(item));
+      }
+      return repositories;
+    } else {
+      return repositories;
+    }
   }
 }

--- a/lib/home/home_view_model.dart
+++ b/lib/home/home_view_model.dart
@@ -22,4 +22,9 @@ class HomeViewModel extends StateNotifier<AsyncValue<HomeState>> {
       ),
     );
   }
+
+  // textFieldとstateの対応
+  void changeSearchWord(String value) {
+    state = AsyncValue.data(state.value!.copyWith(searchWord: value));
+  }
 }

--- a/lib/models/repository.dart
+++ b/lib/models/repository.dart
@@ -1,0 +1,31 @@
+class Repository {
+  final String name;
+  final String ownerIconUrl;
+  final String language;
+  final int starCount;
+  final int watcherCount;
+  final int forkCount;
+  final int issueCount;
+
+  Repository({
+    required this.name,
+    required this.ownerIconUrl,
+    required this.language,
+    required this.starCount,
+    required this.watcherCount,
+    required this.forkCount,
+    required this.issueCount,
+  });
+
+  factory Repository.fromJson(Map<String, dynamic> item) {
+    return Repository(
+        name: item['name'],
+        ownerIconUrl: item['owner']['avatar_url'],
+        language: item['language'] ?? '',
+        starCount: item['stars_count'] ?? 0,
+        watcherCount: item['watchers_count'] ?? 0,
+        forkCount: item['forks_count'] ?? 0,
+        issueCount: item['issues_count'] ?? 0,
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -242,6 +242,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
+  http:
+    dependency: "direct main"
+    description:
+      name: http
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.13.4"
   http_multi_server:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   flutter_riverpod: ^1.0.4
   freezed: ^2.0.5
   freezed_annotation: ^2.0.3
+  http: ^0.13.4
 
 dev_dependencies:
   build_runner: ^2.2.0


### PR DESCRIPTION
## 概要
以下の２つの機能を追加
- Githubレポジトリの検索
- 検索したレポジトリの名前一覧をHomePageに表示

## 詳細
GitHub API(search/repositories) を使用して、レポジトリを検索した。
APIの詳細: https://docs.github.com/ja/rest/search#search-repositories 

FloatingActionButtonを押した時にTextFormFieldの文字列から検索される。

## Todo
- TextFormFieldの文字列が確定した段階でレポジトリの一覧が表示されるようにする
